### PR TITLE
Update link to Pub/Sub course.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # learn-pub-sub-starter (Peril)
 
-This is the starter code used in Boot.dev's [Learn Pub/Sub](https://learn.boot.dev/learn-pub-sub) course.
+This is the starter code used in Boot.dev's [Learn Pub/Sub](https://boot.dev/courses/learn-pub-sub-rabbitmq-golang) course.


### PR DESCRIPTION
Old link was invalid. Changed it to new link from boot.dev.